### PR TITLE
Fix task link bug in popup

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -259,7 +259,17 @@ class ActionLayer3Popup {
     tasks.forEach((task) => {
       const li = document.createElement("li");
       li.textContent = task.text;
-      li.addEventListener("click", () => chrome.tabs.create({ url: task.pageUrl }));
+
+      // Tasks created by other parts of the extension use the `url` field.
+      // Older tasks may still store `pageUrl`, so support both to avoid
+      // opening a blank tab when `pageUrl` is undefined.
+      const targetUrl = task.url || task.pageUrl || undefined;
+      if (targetUrl) {
+        li.addEventListener("click", () =>
+          chrome.tabs.create({ url: targetUrl })
+        );
+      }
+
       this.taskList.appendChild(li);
     });
   }


### PR DESCRIPTION
## Summary
- ensure popup can open tasks from newer extension versions

## Testing
- `find src -name '*.js' -print0 | xargs -0 -n1 node -c`

------
https://chatgpt.com/codex/tasks/task_e_684639f4740c83308ede4db138ad3d2e